### PR TITLE
Add mutex to prevent race condition in TimersManager destructor

### DIFF
--- a/irobot_events_executor/include/rclcpp/timers_manager.hpp
+++ b/irobot_events_executor/include/rclcpp/timers_manager.hpp
@@ -486,6 +486,8 @@ private:
   std::thread timers_thread_;
   // Protects access to timers
   std::mutex timers_mutex_;
+  // Protects access to stop()
+  std::mutex stop_mutex_;
   // Notifies the timers thread whenever timers are added/removed
   std::condition_variable timers_cv_;
   // Flag used as predicate by timers_cv_ that denotes one or more timers being added/removed

--- a/irobot_events_executor/src/rclcpp/timers_manager.cpp
+++ b/irobot_events_executor/src/rclcpp/timers_manager.cpp
@@ -59,6 +59,8 @@ void TimersManager::start()
 
 void TimersManager::stop()
 {
+  // Lock stop() function to prevent race condition in destructor
+  std::unique_lock<std::mutex> lock(stop_mutex_);
   // Nothing to do if the timers thread is not running
   // or if another thread already signaled to stop.
   if (!running_.exchange(false)) {


### PR DESCRIPTION
## Description
A race condition can happen when TimersManager's stop() function is called while EventsExecutor::spin() is exiting before TimersManager's destructor is called and uses the stop() to check if timers_thread_ has been joined.

## Motivation and Context
It fixes the SIGABRT captured in the backtrace below.
 
```
Thread 1 "kinematics-engi" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff6544859 in __GI_abort () at abort.c:79
#2  0x00007ffff691c911 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff692838c in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff69283f7 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff7a7e7a0 in rclcpp::executors::TimersManager::~TimersManager() () from ...
```

## How Has This Been Tested?
Ran the same internal unit test in which we discovered the issue on repeat 100 times and verified that the SIGABRT no longer happens.
