### PR TITLE
Set spinning to false in ~EventsExecutor

### DIFF
--- a/irobot_events_executor/include/rclcpp/executors/events_executor/events_executor.hpp
+++ b/irobot_events_executor/include/rclcpp/executors/events_executor/events_executor.hpp
@@ -62,9 +62,9 @@ public:
     bool execute_timers_separate_thread = false,
     const rclcpp::ExecutorOptions & options = rclcpp::ExecutorOptions());
 
-  /// Default destrcutor.
+  /// Default destructor.
   RCLCPP_PUBLIC
-  virtual ~EventsExecutor() = default;
+  virtual ~EventsExecutor();
 
   /// Events executor implementation of spin.
   /**

--- a/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
+++ b/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
@@ -50,6 +50,11 @@ EventsExecutor::EventsExecutor(
   entities_collector_->add_waitable(executor_notifier_);
 }
 
+EventsExecutor::~EventsExecutor()
+{
+  spinning.store(false);
+};
+
 void
 EventsExecutor::spin()
 {


### PR DESCRIPTION
So if the executor is spinning and goes out of scope, it can exit the spin loop