### PR TITLE
Remove interface install from CMakeLists.txt

### DIFF
--- a/irobot_lock_free_events_queue/CMakeLists.txt
+++ b/irobot_lock_free_events_queue/CMakeLists.txt
@@ -26,13 +26,6 @@ ament_target_dependencies(irobot_lock_free_events_queue INTERFACE
   "rclcpp"
 )
 
-install(TARGETS
-  irobot_lock_free_events_queue
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
 install(DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
 )


### PR DESCRIPTION
It is not required and leads to problems with symlink install (see https://github.com/ament/ament_cmake/issues/412).