### PR TITLE
Fix timers-manager segfault

### DIFF
--- a/irobot_events_executor/src/rclcpp/timers_manager.cpp
+++ b/irobot_events_executor/src/rclcpp/timers_manager.cpp
@@ -61,16 +61,7 @@ void TimersManager::stop()
 {
   // Lock stop() function to prevent race condition in destructor
   std::unique_lock<std::mutex> lock(stop_mutex_);
-
-  // Nothing to do if the timers thread is not running
-  // or if another thread already signaled to stop.
-  if (!running_.exchange(false)) {
-    // Join timers thread if it's running
-    if (timers_thread_.joinable()) {
-      timers_thread_.join();
-    }
-    return;
-  }
+  running_ = false;
 
   // Notify the timers manager thread to wake up
   {

--- a/irobot_events_executor/src/rclcpp/timers_manager.cpp
+++ b/irobot_events_executor/src/rclcpp/timers_manager.cpp
@@ -61,11 +61,7 @@ void TimersManager::stop()
 {
   // Lock stop() function to prevent race condition in destructor
   std::unique_lock<std::mutex> lock(stop_mutex_);
-  // Nothing to do if the timers thread is not running
-  // or if another thread already signaled to stop.
-  if (!running_.exchange(false)) {
-    return;
-  }
+  running_ = false;
 
   // Notify the timers manager thread to wake up
   {


### PR DESCRIPTION
The issue was that `running_` was set to false here:

https://github.com/irobot-ros/events-executor/blob/6f4343fc1e7d7719cabe0f14059c897b9698cf5a/irobot_events_executor/src/rclcpp/timers_manager.cpp#L257

So then, in destructor, it didn't wait for the thread to join here:
https://github.com/irobot-ros/events-executor/blob/6f4343fc1e7d7719cabe0f14059c897b9698cf5a/irobot_events_executor/src/rclcpp/timers_manager.cpp#L66-L68

Was that check done to gain some performance? Or some other reason I ignore?
