### PR TITLE
Apply fixes: Callback groups guard condition

### DIFF
--- a/irobot_events_executor/include/rclcpp/executors/entities_collector_base.hpp
+++ b/irobot_events_executor/include/rclcpp/executors/entities_collector_base.hpp
@@ -181,6 +181,14 @@ protected:
   void
   add_callback_groups_from_nodes_associated_to_executor();
 
+  typedef std::map<rclcpp::CallbackGroup::WeakPtr,
+    rclcpp::GuardCondition *,
+    std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
+  WeakCallbackGroupsToGuardConditionsMap;
+
+  /// maps callback groups to guard conditions
+  WeakCallbackGroupsToGuardConditionsMap weak_groups_to_guard_conditions_;
+
   // maps callback groups to nodes.
   WeakCallbackGroupsToNodesMap weak_groups_associated_with_executor_to_nodes_;
   // maps callback groups to nodes.

--- a/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor_entities_collector.cpp
+++ b/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor_entities_collector.cpp
@@ -55,11 +55,21 @@ EventsExecutorEntitiesCollector::~EventsExecutorEntitiesCollector()
     }
   }
 
+  // Unset callback group notify guard condition executor callback
+  for (const auto & pair : weak_groups_to_guard_conditions_) {
+    auto group = pair.first.lock();
+    if (group) {
+      auto & group_gc = pair.second;
+      unset_guard_condition_callback(group_gc);
+    }
+  }
+
   weak_clients_map_.clear();
   weak_services_map_.clear();
   weak_waitables_map_.clear();
   weak_subscriptions_map_.clear();
   weak_nodes_to_guard_conditions_.clear();
+  weak_groups_to_guard_conditions_.clear();
 }
 
 void
@@ -107,6 +117,15 @@ EventsExecutorEntitiesCollector::callback_group_added_impl(
   rclcpp::CallbackGroup::SharedPtr group)
 {
   std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
+  rclcpp::CallbackGroup::WeakPtr weak_group_ptr = group;
+
+  auto iter = weak_groups_to_guard_conditions_.find(weak_group_ptr);
+  if (iter != weak_groups_to_guard_conditions_.end()) {
+    // Set an event callback for the group's notify guard condition, so if new entities are added
+    // or removed to this node we will receive an event.
+    set_guard_condition_callback(iter->second);
+  }
   // For all entities in the callback group, set their event callback
   set_callback_group_entities_callbacks(group);
 }
@@ -224,6 +243,12 @@ void
 EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   rclcpp::CallbackGroup::SharedPtr group)
 {
+  auto iter = weak_groups_to_guard_conditions_.find(group);
+
+  if (iter != weak_groups_to_guard_conditions_.end()) {
+    unset_guard_condition_callback(iter->second);
+  }
+
   // Timers are handled by the timers manager
   group->find_timer_ptrs_if(
     [this](const rclcpp::TimerBase::SharedPtr & timer) {


### PR DESCRIPTION
Apply these changes to the EventsExecutor, to wake up when entities are added to callback groups registered on it.

https://github.com/ros2/rclcpp/pull/1640/files
https://github.com/irobot-ros/events-executor/pull/12/files
https://github.com/ros2/rclcpp/pull/2074/files