### PR TITLE
do not try to execute head timer in spin_once_impl

### DIFF
--- a/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
+++ b/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
@@ -159,9 +159,11 @@ EventsExecutor::spin_once_impl(std::chrono::nanoseconds timeout)
   }
 
   // Select the smallest between input timeout and timer timeout
+  bool is_timer_timeout = false;
   auto next_timer_timeout = timers_manager_->get_head_timeout();
   if (next_timer_timeout < timeout) {
     timeout = next_timer_timeout;
+    is_timer_timeout = true;
   }
 
   ExecutorEvent event;
@@ -171,7 +173,7 @@ EventsExecutor::spin_once_impl(std::chrono::nanoseconds timeout)
   // arrived before any of the timers expired.
   if (has_event) {
     this->execute_event(event);
-  } else {
+  } else if (is_timer_timeout) {
     timers_manager_->execute_head_timer();
   }
 }


### PR DESCRIPTION
do not try to execute head timer in spin_once_impl if we are not waiting for it

This fixes an inefficiency that would occur when:
 - `next_timer_timeout` is greater than the input `timeout`
 - there are no available events

in this situation, `bool has_event = events_queue_->dequeue(event, timeout);` would timeout returning false, but we don't want to execute the head timeout.